### PR TITLE
改错

### DIFF
--- a/source/chapter2/11_Methods.md
+++ b/source/chapter2/11_Methods.md
@@ -224,7 +224,7 @@ ovenLight.next()
 
 ```swift
 class SomeClass {
-    static func someTypeMethod() {
+    class func someTypeMethod() {
         // type method implementation goes here
     }
 }


### PR DESCRIPTION
类型方法代码写成static func 原文为 class func