### PR TITLE
校正+翻译 From SketchK

### DIFF
--- a/source/chapter2/08_Enumerations.md
+++ b/source/chapter2/08_Enumerations.md
@@ -10,7 +10,10 @@
 
 > 2.1
 > 翻译：[Channe](https://github.com/Channe)
-> 校对：[shanks](http://codebuild.me)
+> 校对：[shanks](http://codebuild.me)，
+
+> 2.2
+> 翻译+校对：[SketchK](https://github.com/SketchK) 2016-05-13
 
 本页内容包含：
 
@@ -293,11 +296,8 @@ if let somePlanet = Planet(rawValue: positionToFind) {
 <a name="recursive_enumerations"></a>
 ## 递归枚举（Recursive Enumerations）
 
-当各种可能的情况可以被穷举时，非常适合使用枚举进行数据建模，例如可以用枚举来表示用于简单整数运算的操作符。这些操作符让你可以将简单的算术表达式，例如整数`5`，结合为更为复杂的表达式，例如`5 + 4`。
 
-算术表达式的一个重要特性是，表达式可以嵌套使用。例如，表达式`(5 + 4) * 2`，乘号右边是一个数字，左边则是另一个表达式。因为数据是嵌套的，因而用来存储数据的枚举类型也需要支持这种嵌套——这意味着枚举类型需要支持递归。
-
-*递归枚举（recursive enumeration）*是一种枚举类型，它有一个或多个枚举成员使用该枚举类型的实例作为关联值。使用递归枚举时，编译器会插入一个间接层。你可以在枚举成员前加上`indirect`来表示该成员可递归。
+*递归枚举（recursive enumeration）*是一种枚举类型，它有一个或多个枚举成员使用该枚举类型的实例作为关联值。使用递归枚举时，编译器会插入一个间接层。你可以在枚举成员前加上`indirect`来表示该成员可递归。  
 
 例如，下面的例子中，枚举类型存储了简单的算术表达式：
 
@@ -319,7 +319,14 @@ indirect enum ArithmeticExpression {
 }
 ```
 
-上面定义的枚举类型可以存储三种算术表达式：纯数字、两个表达式相加、两个表达式相乘。枚举成员`Addition`和`Multiplication`的关联值也是算术表达式——这些关联值使得嵌套表达式成为可能。
+上面定义的枚举类型可以存储三种算术表达式：纯数字、两个表达式相加、两个表达式相乘。枚举成员`Addition`和`Multiplication`的关联值也是算术表达式——这些关联值使得嵌套表达式成为可能。例如，表达式`(5 + 4) * 2`，乘号右边是一个数字，左边则是另一个表达式。因为数据是嵌套的，因而用来存储数据的枚举类型也需要支持这种嵌套——这意味着枚举类型需要支持递归。下面的代码展示了使用`ArithmeticExpression `这个递归枚举创建表达式`(5 + 4) * 2`
+
+```swift
+let five = ArithmeticExpression.Number(5)
+let four = ArithmeticExpression.Number(4)
+let sum = ArithmeticExpression.Addition(five, four)
+let product = ArithmeticExpression.Multiplication(sum, ArithmeticExpression.Number(2))
+```
 
 要操作具有递归性质的数据结构，使用递归函数是一种直截了当的方式。例如，下面是一个对算术表达式求值的函数：
 
@@ -334,12 +341,7 @@ func evaluate(expression: ArithmeticExpression) -> Int {
         return evaluate(left) * evaluate(right)
     }
 }
- 
-// 计算 (5 + 4) * 2
-let five = ArithmeticExpression.Number(5)
-let four = ArithmeticExpression.Number(4)
-let sum = ArithmeticExpression.Addition(five, four)
-let product = ArithmeticExpression.Multiplication(sum, ArithmeticExpression.Number(2))
+
 print(evaluate(product))
 // 输出 "18"
 ```

--- a/source/chapter2/09_Classes_and_Structures.md
+++ b/source/chapter2/09_Classes_and_Structures.md
@@ -10,6 +10,9 @@
 > 2.1
 > 校对：[shanks](http://codebuild.me)，2015-10-29
 
+> 2.2
+> 校对：[SketchK](https://github.com/SketchK) 2016-05-13
+
 本页包含内容：
 
 - [类和结构体对比](#comparing_classes_and_structures)

--- a/source/chapter2/10_Properties.md
+++ b/source/chapter2/10_Properties.md
@@ -16,7 +16,7 @@
 
 
 >   2.2
->   翻译：[saitjr](https://github.com/saitjr)，2016-04-11
+>   翻译：[saitjr](https://github.com/saitjr)，2016-04-11，[SketchK](https://github.com/SketchK) 2016-05-13
 
 
 
@@ -41,7 +41,7 @@
 
 可以在定义存储属性的时候指定默认值，请参考[默认构造器](./14_Initialization.html#default_initializers)一节。也可以在构造过程中设置或修改存储属性的值，甚至修改常量存储属性的值，请参考[构造过程中常量属性的修改](./14_Initialization.html#assigning_constant_properties_during_initialization)一节。
 
-下面的例子定义了一个名为 `FixedLengthRange` 的结构体，它描述了一个用于表示整型范围的常量，在创建后就不能进行修改：
+下面的例子定义了一个名为 `FixedLengthRange` 的结构体，该结构体用于描述整数的范围，且这个范围值在被创建后不能被修改.
 
 ```swift
 struct FixedLengthRange {

--- a/source/chapter2/11_Methods.md
+++ b/source/chapter2/11_Methods.md
@@ -9,7 +9,10 @@
 > 翻译+校对：[DianQK](https://github.com/DianQK)
 
 > 2.1
-> 翻译：[DianQK](https://github.com/DianQK)，[Realank](https://github.com/Realank) 校对：[shanks](http://codebuild.me)，2016-01-18
+> 翻译：[DianQK](https://github.com/DianQK)，[Realank](https://github.com/Realank) 校对：[shanks](http://codebuild.me)，2016-01-18  
+> 
+> 2.2
+> 校对：[SketchK](https://github.com/SketchK) 2016-05-13
 
 本页包含内容：
 
@@ -33,7 +36,7 @@
 class Counter {
     var count = 0
     func increment() {
-        ++count
+        count += 1
     }
     func incrementBy(amount: Int) {
         count += amount
@@ -112,7 +115,7 @@ counter.incrementBy(5, numberOfTimes: 3)
 
 ```swift
 func increment() {
-    self.count++
+    self.count += 1
 }
 ```
 

--- a/source/chapter2/12_Subscripts.md
+++ b/source/chapter2/12_Subscripts.md
@@ -9,7 +9,10 @@
 > 翻译+校对：[shanks](http://codebuild.me)
 
 > 2.1
-> 翻译+校对：[shanks](http://codebuild.me)，[Realank](https://github.com/Realank)
+> 翻译+校对：[shanks](http://codebuild.me)，[Realank](https://github.com/Realank)  
+
+> 2.2
+> 校对：[SketchK](https://github.com/SketchK) 2016-05-13
 
 
 本页包含内容：

--- a/source/chapter2/13_Inheritance.md
+++ b/source/chapter2/13_Inheritance.md
@@ -7,6 +7,9 @@
 
 > 2.0，2.1
 > 翻译+校对：[shanks](http://codebuild.me)
+> 
+> 2.2
+> 校对：[SketchK](https://github.com/SketchK) 2016-05-13
 
 本页包含内容：
 
@@ -233,6 +236,6 @@ print("AutomaticCar: \(automatic.description)")
 
 你可以通过把方法，属性或下标标记为*`final`*来防止它们被重写，只需要在声明关键字前加上`final`修饰符即可（例如：`final var`，`final func`，`final class func`，以及`final subscript`）。
 
-如果你重写了`final`方法，属性或下标，在编译时会报错。在类扩展中的方法，属性或下标也可以在扩展的定义里标记为 final 的。
+如果你重写了带有`final`标记的方法，属性或下标，在编译时会报错。在类扩展中的方法，属性或下标也可以在扩展的定义里标记为 final 的。
 
 你可以通过在关键字`class`前添加`final`修饰符（`final class`）来将整个类标记为 final 的。这样的类是不可被继承的，试图继承这样的类会导致编译报错。


### PR DESCRIPTION
主要内容
1 `枚举`章节中的`递归枚举`一节中文章内容更新(原文与当前翻译内容不相符)
2 `属性`章节中的`存储属性`一节中的文字内容纠正(原文与当前翻译内容不相符)
3 `方法`章节中的`实例方法`的代码有误(++符号废弃)
4 `方法`章节中`self属性`的代码有误作(++符号废弃)
5 `继承`章节中`防止重写`一节中的文字内容纠正(原文与当前翻译中的内容不相符)
6  校正了"类和结构体","下标"两章的内容,没有发现明显错误